### PR TITLE
fix: report API limit error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 *.tgz
+node_modules/

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { newerVersion } from './index'
+import { newerVersion, fetchLatest } from "./index";
 
 test('compare versions', () => {
   expect(newerVersion("0.1.0", "0.0.1")).toBe(true)
@@ -9,3 +9,31 @@ test('compare versions', () => {
   expect(newerVersion("v0.0.1", "v0.0.1")).toBe(false)
   expect(newerVersion("", "0.0.1")).toBe(false)
 })
+
+jest.mock('node-fetch');
+
+describe('fetchLatest', () => {
+  test('should throw error when api limit is reached', async () => {
+    const fetch = require("node-fetch");
+    const response = {
+      status: 403,
+      json: () =>
+        Promise.resolve({
+          message: 'API rate limit exceeded for ',
+        }),
+    };
+    fetch.mockResolvedValue(response)
+
+    await expect(
+      fetchLatest({
+        repository: 'netlify/test',
+        package: 'test',
+        destination: 'bin/test',
+        version: '1.0.0',
+        extract: true,
+      })
+    ).rejects.toEqual(
+      new Error('API rate limit exceeded, please try again later')
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,17 @@ export async function updateAvailable(repository: string, currentVersion: string
 }
 
 async function resolveRelease(repository: string): Promise<string> {
-  const res = await fetch(`https://api.github.com/repos/${repository}/releases/latest`);
+  const res = await fetch(
+    `https://api.github.com/repos/${repository}/releases/latest`
+  );
   const json = await res.json();
+  if (
+    res.status === 403 &&
+    typeof json.message === 'string' &&
+    json.message.includes('API rate limit exceeded')
+  ) {
+    throw new Error('API rate limit exceeded, please try again later');
+  }
   return json.tag_name;
 }
 


### PR DESCRIPTION
Related to https://github.com/netlify/cli/issues/445

Report an error message when the API limit is reached instead of `TypeError: Invalid Version: undefined`