### PR TITLE
feat: allow passing fetch options

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,39 +1,77 @@
 import { newerVersion, fetchLatest } from "./index";
 
-test('compare versions', () => {
-  expect(newerVersion("0.1.0", "0.0.1")).toBe(true)
-  expect(newerVersion("v0.1.0", "v0.0.1")).toBe(true)
-  expect(newerVersion("v0.0.1", "")).toBe(true)
+test("compare versions", () => {
+  expect(newerVersion("0.1.0", "0.0.1")).toBe(true);
+  expect(newerVersion("v0.1.0", "v0.0.1")).toBe(true);
+  expect(newerVersion("v0.0.1", "")).toBe(true);
 
-  expect(newerVersion("0.0.1", "0.0.1")).toBe(false)
-  expect(newerVersion("v0.0.1", "v0.0.1")).toBe(false)
-  expect(newerVersion("", "0.0.1")).toBe(false)
-})
+  expect(newerVersion("0.0.1", "0.0.1")).toBe(false);
+  expect(newerVersion("v0.0.1", "v0.0.1")).toBe(false);
+  expect(newerVersion("", "0.0.1")).toBe(false);
+});
 
-jest.mock('node-fetch');
+jest.mock("node-fetch");
+jest.mock("download");
 
-describe('fetchLatest', () => {
-  test('should throw error when api limit is reached', async () => {
+describe("fetchLatest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should throw error when api limit is reached", async () => {
     const fetch = require("node-fetch");
     const response = {
       status: 403,
       json: () =>
         Promise.resolve({
-          message: 'API rate limit exceeded for ',
+          message: "API rate limit exceeded for ",
         }),
     };
-    fetch.mockResolvedValue(response)
+    fetch.mockResolvedValue(response);
 
     await expect(
       fetchLatest({
-        repository: 'netlify/test',
-        package: 'test',
-        destination: 'bin/test',
-        version: '1.0.0',
+        repository: "netlify/test",
+        package: "test",
+        destination: "bin/test",
+        version: "1.0.0",
         extract: true,
       })
     ).rejects.toEqual(
-      new Error('API rate limit exceeded, please try again later')
+      new Error("API rate limit exceeded, please try again later")
+    );
+  });
+
+  test("should add fetch options to API call when passed as a second argument", async () => {
+    const fetch = require("node-fetch");
+    const response = {
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tag_name: "v1.0.0",
+        }),
+    };
+    fetch.mockResolvedValue(response);
+
+    await expect(
+      fetchLatest(
+        {
+          repository: "netlify/test",
+          package: "test",
+          destination: "bin/test",
+          version: "1.0.0",
+          extract: true,
+        },
+        { headers: { Authorization: "token some_token" } }
+      )
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(
+      fetch
+    ).toHaveBeenCalledWith(
+      "https://api.github.com/repos/netlify/test/releases/latest",
+      { headers: { Authorization: "token some_token" } }
     );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/netlify/gh-release-fetch/issues/11

This allows passing fetch options to relevant methods. For `downloadFile` we can't use the options as is, as it uses `got` and not `node-fetch`. Instead of converting `fetch` options, I chose to pass only the relevant ones at the moment (which is `agent` - that is useful when using Netlify CLI with a proxy server).