### PR TITLE
chore!: remove make-dir package and use native, drop Node.js 10 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6526,6 +6526,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -6533,7 +6534,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fetch"
   ],
   "engines": {
-    "node": ">=10"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "author": "David Calavera",
   "license": "MIT",
@@ -56,7 +56,6 @@
     "@types/node-fetch": "^2.1.6",
     "@types/semver": "^7.0.0",
     "download": "^8.0.0",
-    "make-dir": "^3.1.0",
     "node-fetch": "^2.3.0",
     "semver": "^7.0.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
+import { promises as fs } from 'fs'
 import { Agent } from 'http'
 
 import download from 'download'
-import makeDir from 'make-dir'
 import fetch, { RequestInit } from 'node-fetch'
 import { gt } from 'semver'
 
@@ -47,7 +47,7 @@ async function resolveRelease(repository: string, fetchOptions?: RequestInit): P
 
 async function downloadFile(release: Release, { agent }: DownloadOptions) {
   const url = `https://github.com/${release.repository}/releases/download/${release.version}/${release.package}`
-  await makeDir(release.destination)
+  await fs.mkdir(release.destination, { recursive: true })
   await download(url, release.destination, {
     extract: release.extract,
     agent: agent as Agent,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
This requires a change in the engines version since `fs.mkdir`'s recursive option requires >= 10.12.0.