### PR TITLE
chore: remove unneeded devDependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,5 @@
-const { overrides } = require('@netlify/eslint-config-node')
-
 module.exports = {
   extends: '@netlify/eslint-config-node',
-  // TODO: remove after https://github.com/netlify/eslint-config-node/pull/230 is merged and released
   rules: {
     'node/no-unsupported-features/es-syntax': [
       'error',
@@ -11,34 +8,5 @@ module.exports = {
       },
     ],
     'func-style': ['error', 'declaration'],
-  },
-  overrides: [
-    ...overrides,
-    // TODO: remove after https://github.com/netlify/eslint-config-node/pull/230 is merged and released
-    {
-      files: ['*.ts'],
-      extends: [
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:import/typescript',
-      ],
-    },
-  ],
-  settings: {
-    // TODO: remove after https://github.com/netlify/eslint-config-node/pull/230 is merged and released
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
-    },
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.d.ts', '.ts', '.tsx'],
-      },
-      typescript: {
-        alwaysTryTypes: true,
-      },
-    },
-    node: {
-      tryExtensions: ['.js', '.ts', '.d.ts'],
-    },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,6 @@
         "@netlify/eslint-config-node": "^4.0.6",
         "@types/jest": "^27.0.0",
         "@types/node": "^16.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "husky": "^4.3.8",
         "jest": "^27.0.0",
         "ts-jest": "^27.0.0",
         "typescript": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "@netlify/eslint-config-node": "^4.0.6",
     "@types/jest": "^27.0.0",
     "@types/node": "^16.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
-    "husky": "^4.3.8",
     "jest": "^27.0.0",
     "ts-jest": "^27.0.0",
     "typescript": "^4.0.0"


### PR DESCRIPTION
These are inherited from the `@netlify/eslint-config-node`

Unsure about husky, but it's also included in `@netlify/eslint-config-node`