### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/workflow-backend
+.github/CODEOWNERS  @netlify/netlify-dev


### PR DESCRIPTION
This should be the same as https://github.com/netlify/cli/blob/47bf5eb7df9dfaf1ba9571cc9fc1b403935f0474/.github/CODEOWNERS